### PR TITLE
Redesign: new design system and UI refresh

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -315,12 +315,17 @@ a {
     font-style: italic;
 }
 
+#card-plainwords {
+    aspect-ratio: 7 / 3;
+    transform: rotate(-1.5deg);
+}
+
 #card-bandcamp {
     --pkg-surface: #1da0c3;
     --pkg-shadow: 0 1px 4px rgba(0,0,0,0.14), 0 6px 20px rgba(0,0,0,0.20);
     --pkg-muted: rgba(255,255,255,0.58);
     aspect-ratio: 1 / 1;
-    transform: rotate(-2deg);
+    transform: rotate(-3deg);
     color: #fff;
 }
 
@@ -338,7 +343,7 @@ a {
     --pkg-shadow: 0 1px 4px rgba(0,0,0,0.14), 0 6px 20px rgba(0,0,0,0.20);
     --pkg-muted: rgba(255,255,255,0.58);
     aspect-ratio: 1 / 1;
-    transform: rotate(-1.5deg);
+    transform: rotate(2.8deg);
     color: #fff;
 }
 
@@ -347,7 +352,7 @@ a {
     --pkg-shadow: 0 1px 4px rgba(0,0,0,0.14), 0 6px 20px rgba(0,0,0,0.20);
     --pkg-muted: rgba(255,255,255,0.58);
     aspect-ratio: 2 / 3;
-    transform: rotate(2.5deg);
+    transform: rotate(-0.4deg);
     color: #fff;
 }
 
@@ -367,7 +372,15 @@ a {
     border-color: rgba(255,255,255,0.42);
 }
 
+/* Plainwords is a white card — restore tag colour */
+#card-plainwords .pkg-tag {
+    color: var(--fg);
+    background: color-mix(in srgb, currentColor 14%, transparent);
+    border-color: currentColor;
+}
+
 /* Secondary/tertiary name sizes */
+#card-plainwords .pkg-name,
 #card-bandcamp .pkg-name,
 #card-soundcloud .pkg-name,
 #card-instagram .pkg-name,
@@ -379,17 +392,18 @@ a {
 
 /* ── Grid placement — 12 cols ───────────────────────────────────────────────
  *
- * Row 1: [01 Works: 1–7]              [col 8 gap]  [02 Events: 9–12]
- * Row 2: [03 Note: 1–8]              [col 9 gap]   [04 Bandcamp: 10–12]
- * Row 3: [col 1 gap] [05 Sound: 2–4] [gap] [06 Insta: 5–8] [gap] [07 X: 10–12]
- * Row 4:                [gap 1–3]    [08 Email: 4–8]
+ * Row 1: [01 Works: 1–7]           [col 8 gap]  [02 Events: 9–12]
+ * Row 2: [03 Note: 1–9]            [col 9 gap]  [04 Plainwords: 10–12]
+ * Row 3: [05 Bandcamp: 1–3] [06 Sound: 4–6] [07 Insta: 7–9] [08 X: 10–12]
+ * Row 4:              [gap 1–3]    [09 Email: 4–8]
  */
 #card-works      { grid-column: 1 / 8;  }
 #card-events     { grid-column: 9 / 13; }
-#card-note       { grid-column: 1 / 9;  }
-#card-bandcamp   { grid-column: 10 / 13; }
-#card-soundcloud { grid-column: 2 / 5;  }
-#card-instagram  { grid-column: 5 / 9;  }
+#card-note       { grid-column: 1 / 7;  }
+#card-plainwords { grid-column: 7 / 13; }
+#card-bandcamp   { grid-column: 1 / 4;  }
+#card-soundcloud { grid-column: 4 / 7;  }
+#card-instagram  { grid-column: 7 / 10; }
 #card-x          { grid-column: 10 / 13; }
 #card-email      { grid-column: 4 / 9;  }
 
@@ -404,10 +418,11 @@ a {
 
     #card-works      { grid-column: 1 / 5; }
     #card-events     { grid-column: 5 / 7; }
-    #card-note       { grid-column: 1 / 5; aspect-ratio: 5 / 3; }
-    #card-bandcamp   { grid-column: 5 / 7; }
-    #card-soundcloud { grid-column: 1 / 3; }
-    #card-instagram  { grid-column: 3 / 6; }
+    #card-note       { grid-column: 1 / 4; aspect-ratio: 5 / 3; }
+    #card-plainwords { grid-column: 4 / 7; }
+    #card-bandcamp   { grid-column: 1 / 3; }
+    #card-soundcloud { grid-column: 3 / 5; }
+    #card-instagram  { grid-column: 5 / 7; }
     #card-x          { grid-column: 1 / 3; }
     #card-email      { grid-column: 3 / 7; aspect-ratio: 4 / 3; }
 
@@ -433,6 +448,7 @@ a {
     #card-events,
     #card-note   { grid-column: 1 / -1; }
 
+    #card-plainwords,
     #card-bandcamp,
     #card-soundcloud,
     #card-instagram,

--- a/index.html
+++ b/index.html
@@ -74,9 +74,24 @@
                 <div class="pkg-id">KMG–03</div>
             </article>
 
-            <article class="pkg-card" id="card-bandcamp">
+            <article class="pkg-card" id="card-plainwords">
                 <div class="pkg-corner" aria-hidden="true">
                     <span class="pkg-bg-num">04</span>
+                    <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                    </svg>
+                </div>
+                <div class="pkg-tag" data-cat="article">Article</div>
+                <a class="pkg-name" href="https://plainwords.net/users/kissmenerdygirl" target="_blank" rel="noopener me">Plainwords</a>
+                <div class="pkg-meta">
+                    <span>SOURCE — plainwords.net</span>
+                </div>
+                <div class="pkg-id">KMG–04</div>
+            </article>
+
+            <article class="pkg-card" id="card-bandcamp">
+                <div class="pkg-corner" aria-hidden="true">
+                    <span class="pkg-bg-num">05</span>
                     <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
                     </svg>
@@ -86,12 +101,12 @@
                 <div class="pkg-meta">
                     <span>FORMAT — Digital</span>
                 </div>
-                <div class="pkg-id">KMG–04</div>
+                <div class="pkg-id">KMG–05</div>
             </article>
 
             <article class="pkg-card" id="card-soundcloud">
                 <div class="pkg-corner" aria-hidden="true">
-                    <span class="pkg-bg-num">05</span>
+                    <span class="pkg-bg-num">06</span>
                     <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
                     </svg>
@@ -101,12 +116,12 @@
                 <div class="pkg-meta">
                     <span>FORMAT — Stream</span>
                 </div>
-                <div class="pkg-id">KMG–05</div>
+                <div class="pkg-id">KMG–06</div>
             </article>
 
             <article class="pkg-card" id="card-instagram">
                 <div class="pkg-corner" aria-hidden="true">
-                    <span class="pkg-bg-num">06</span>
+                    <span class="pkg-bg-num">07</span>
                     <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/>
                     </svg>
@@ -116,12 +131,12 @@
                 <div class="pkg-meta">
                     <span>FORMAT — Photo / Video</span>
                 </div>
-                <div class="pkg-id">KMG–06</div>
+                <div class="pkg-id">KMG–07</div>
             </article>
 
             <article class="pkg-card" id="card-x">
                 <div class="pkg-corner" aria-hidden="true">
-                    <span class="pkg-bg-num">07</span>
+                    <span class="pkg-bg-num">08</span>
                     <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                     </svg>
@@ -131,12 +146,12 @@
                 <div class="pkg-meta">
                     <span>FORMAT — Text</span>
                 </div>
-                <div class="pkg-id">KMG–07</div>
+                <div class="pkg-id">KMG–08</div>
             </article>
 
             <article class="pkg-card" id="card-email">
                 <div class="pkg-corner" aria-hidden="true">
-                    <span class="pkg-bg-num">08</span>
+                    <span class="pkg-bg-num">09</span>
                     <svg class="pkg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,6 12,13 2,6"/>
                     </svg>
@@ -146,7 +161,7 @@
                 <div class="pkg-meta">
                     <span>FORMAT — Direct</span>
                 </div>
-                <div class="pkg-id">KMG–08</div>
+                <div class="pkg-id">KMG–09</div>
             </article>
 
         </div>


### PR DESCRIPTION
## Summary

- CSSをデザイントークンベースに全面リライト（8pxスケール、カラー変数、Inter フォント導入）
- `index.html` にリンクカードグリッドレイアウトを追加（Plainwords カードを含む）
- works ページのカードに連番ラベル（01, 02...）を追加し、テキストゾーンを構造化
- Spotify embed に専用クラス `video-wrapper--spotify` を追加

## Test plan

- [ ] index.html のリンクカードが正しく表示される
- [ ] works ページの番号ラベルが正しく表示される
- [ ] events ページのレイアウトが崩れていない
- [ ] モバイル表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)